### PR TITLE
refactor: ajustado teste quando conta duplicada

### DIFF
--- a/app/gateway/database/postgres/accounts/create_account.go
+++ b/app/gateway/database/postgres/accounts/create_account.go
@@ -8,9 +8,9 @@ import (
 func (repository accountRepository) Create(ctx context.Context, newAccount account.Account) (account.Account, error) {
 	var sqlQuery = `
 	INSERT INTO
-			accounts (id, name, cpf, secret, balance, created_at)
+			accounts (id, name, cpf, secret, balance)
 	VALUES
-			($1, $2, $3, $4, $5, $6)
+			($1, $2, $3, $4, $5)
 	`
 	_, err := repository.db.Exec(
 		sqlQuery,
@@ -19,7 +19,7 @@ func (repository accountRepository) Create(ctx context.Context, newAccount accou
 		newAccount.CPF,
 		newAccount.Secret,
 		newAccount.Balance.ToInt(),
-		newAccount.CreatedAt)
+	)
 
 	if err != nil {
 		return account.Account{}, err

--- a/app/gateway/database/postgres/accounts/create_account_test.go
+++ b/app/gateway/database/postgres/accounts/create_account_test.go
@@ -14,7 +14,6 @@ func Test_Create(t *testing.T) {
 	ctx := context.Background()
 	database := databaseTest
 	accountRepository := NewAccountRepository(database)
-	now := time.Now()
 	testCases := []struct {
 		name      string
 		input     account.Account
@@ -25,29 +24,26 @@ func Test_Create(t *testing.T) {
 		{
 			name: "conta cadastrada com sucesso, quando dados corretos",
 			input: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: now,
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			want: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: now,
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			wantErr: false,
 		},
 		{
 			name: "ao tentar criar a conta apresenta que já existe conta cadastrada com este cpf",
 			input: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: now,
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			runBefore: func(db *sql.DB) {
 				truncateQuery := `TRUNCATE accounts`

--- a/app/gateway/database/postgres/accounts/create_account_test.go
+++ b/app/gateway/database/postgres/accounts/create_account_test.go
@@ -14,6 +14,7 @@ func Test_Create(t *testing.T) {
 	ctx := context.Background()
 	database := databaseTest
 	accountRepository := NewAccountRepository(database)
+	now := time.Now()
 	testCases := []struct {
 		name      string
 		input     account.Account
@@ -28,13 +29,14 @@ func Test_Create(t *testing.T) {
 				Name:      "Joao da Silva",
 				CPF:       "38330499912",
 				Balance:   10000,
-				CreatedAt: time.Now(),
+				CreatedAt: now,
 			},
 			want: account.Account{
-				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:    "Joao da Silva",
-				CPF:     "38330499912",
-				Balance: 10000,
+				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:      "Joao da Silva",
+				CPF:       "38330499912",
+				Balance:   10000,
+				CreatedAt: now,
 			},
 			wantErr: false,
 		},
@@ -45,7 +47,7 @@ func Test_Create(t *testing.T) {
 				Name:      "Joao da Silva",
 				CPF:       "38330499912",
 				Balance:   10000,
-				CreatedAt: time.Now(),
+				CreatedAt: now,
 			},
 			runBefore: func(db *sql.DB) {
 				truncateQuery := `TRUNCATE accounts`
@@ -83,9 +85,6 @@ func Test_Create(t *testing.T) {
 				test.runBefore(database)
 			}
 			got, err := accountRepository.Create(ctx, test.input)
-			if err == nil {
-				test.want.CreatedAt = got.CreatedAt
-			}
 			assert.Equal(t, (err != nil), test.wantErr)
 			assert.Equal(t, test.want, got)
 		})

--- a/app/gateway/database/postgres/accounts/create_account_test.go
+++ b/app/gateway/database/postgres/accounts/create_account_test.go
@@ -46,13 +46,6 @@ func Test_Create(t *testing.T) {
 				Balance: 10000,
 			},
 			runBefore: func(db *sql.DB) {
-				truncateQuery := `TRUNCATE accounts`
-				_, err := db.Exec(truncateQuery)
-
-				if err != nil {
-					t.Errorf(err.Error())
-				}
-
 				sqlQuery :=
 					`
 				INSERT INTO
@@ -60,7 +53,7 @@ func Test_Create(t *testing.T) {
 				VALUES
 					('d3280f8c-570a-450d-89f7-3509bc84980d', 'Joao da Silva', '38330499912', 'password', 100, $1)
 				`
-				_, err = db.Exec(sqlQuery, time.Now())
+				_, err := db.Exec(sqlQuery, time.Now())
 				if err != nil {
 					t.Errorf(err.Error())
 				}
@@ -77,6 +70,7 @@ func Test_Create(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			TruncateTable(database)
 			if test.runBefore != nil {
 				test.runBefore(database)
 			}

--- a/app/gateway/database/postgres/accounts/get_all_test.go
+++ b/app/gateway/database/postgres/accounts/get_all_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"stoneBanking/app/domain/entities/account"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,11 +21,10 @@ func Test_GetAll(t *testing.T) {
 		{
 			name: "localiza todas as contas, quando existe ao menos uma cadastrada",
 			input: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: time.Now(),
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			want:    1,
 			wantErr: false,

--- a/app/gateway/database/postgres/accounts/get_all_test.go
+++ b/app/gateway/database/postgres/accounts/get_all_test.go
@@ -20,7 +20,7 @@ func Test_GetAll(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "localizar todas as contas",
+			name: "localiza todas as contas, quando existe ao menos uma cadastrada",
 			input: account.Account{
 				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
 				Name:      "Joao da Silva",

--- a/app/gateway/database/postgres/accounts/get_all_test.go
+++ b/app/gateway/database/postgres/accounts/get_all_test.go
@@ -33,6 +33,7 @@ func Test_GetAll(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			TruncateTable(database)
 			_, err := accountRepository.Create(ctx, test.input)
 			got, err := accountRepository.GetAll(ctx)
 			assert.Equal(t, (err != nil), test.wantErr)

--- a/app/gateway/database/postgres/accounts/get_by_cpf_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_cpf_test.go
@@ -57,6 +57,7 @@ func Test_GetByCPF(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			TruncateTable(database)
 			_, err := accountRepository.Create(ctx, test.input)
 			got, err := accountRepository.GetByCPF(ctx, test.wanted)
 			if err == nil {

--- a/app/gateway/database/postgres/accounts/get_by_cpf_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_cpf_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"stoneBanking/app/domain/entities/account"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -23,11 +22,10 @@ func Test_GetByCPF(t *testing.T) {
 		{
 			name: "localizada a conta utilizando-se do cpf, e retorna os dados da mesma",
 			input: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: time.Now(),
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			want: account.Account{
 				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
@@ -41,11 +39,10 @@ func Test_GetByCPF(t *testing.T) {
 		{
 			name: "retorna erro ao tentar localizar conta com cpf inexistente",
 			input: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: time.Now(),
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			want: account.Account{
 				ID:      "",

--- a/app/gateway/database/postgres/accounts/get_by_cpf_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_cpf_test.go
@@ -20,7 +20,7 @@ func Test_GetByCPF(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "localizado a conta usando o CPF",
+			name: "localizada a conta utilizando-se do cpf, e retorna os dados da mesma",
 			input: account.Account{
 				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
 				Name:      "Joao da Silva",
@@ -37,7 +37,7 @@ func Test_GetByCPF(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "tentar localizar a conta com cpf inexistente",
+			name: "retorna erro ao tentar localizar conta com cpf inexistente",
 			input: account.Account{
 				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
 				Name:      "Joao da Silva",

--- a/app/gateway/database/postgres/accounts/get_by_cpf_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_cpf_test.go
@@ -17,6 +17,7 @@ func Test_GetByCPF(t *testing.T) {
 		name    string
 		input   account.Account
 		want    account.Account
+		wanted  string
 		wantErr bool
 	}{
 		{
@@ -34,6 +35,7 @@ func Test_GetByCPF(t *testing.T) {
 				CPF:     "38330499912",
 				Balance: 10000,
 			},
+			wanted:  "38330499912",
 			wantErr: false,
 		},
 		{
@@ -48,9 +50,10 @@ func Test_GetByCPF(t *testing.T) {
 			want: account.Account{
 				ID:      "",
 				Name:    "",
-				CPF:     "38330499999",
+				CPF:     "",
 				Balance: 0,
 			},
+			wanted:  "38330499999",
 			wantErr: true,
 		},
 	}
@@ -58,12 +61,12 @@ func Test_GetByCPF(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := accountRepository.Create(ctx, test.input)
-			got, err := accountRepository.GetByCPF(ctx, test.want.CPF)
+			got, err := accountRepository.GetByCPF(ctx, test.wanted)
 			if err == nil {
 				test.want.CreatedAt = got.CreatedAt
 			}
 			assert.Equal(t, (err != nil), test.wantErr)
-			assert.Equal(t, test.want.Name, got.Name)
+			assert.Equal(t, test.want, got)
 		})
 	}
 }

--- a/app/gateway/database/postgres/accounts/get_by_id_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_id_test.go
@@ -3,6 +3,7 @@ package account
 import (
 	"context"
 	"stoneBanking/app/domain/entities/account"
+	"stoneBanking/app/domain/types"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ func Test_GetByID(t *testing.T) {
 		name    string
 		input   account.Account
 		want    account.Account
+		wanted  string
 		wantErr bool
 	}{
 		{
@@ -36,6 +38,7 @@ func Test_GetByID(t *testing.T) {
 				Balance:   10000,
 				CreatedAt: now,
 			},
+			wanted:  "d3280f8c-570a-450d-89f7-3509bc84980d",
 			wantErr: false,
 		}, {
 			name: "retorna dados vazios e erro, ao tentar localizar conta com ID inexistente",
@@ -46,8 +49,9 @@ func Test_GetByID(t *testing.T) {
 				Balance:   10000,
 				CreatedAt: now,
 			},
+			wanted: "d3280f8c-570a-450d-89f7-3509bc849899",
 			want: account.Account{
-				ID:      "d3280f8c-570a-450d-89f7-3509bc849899",
+				ID:      "",
 				Name:    "",
 				CPF:     "",
 				Balance: 0,
@@ -59,9 +63,9 @@ func Test_GetByID(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := accountRepository.Create(ctx, test.input)
-			got, err := accountRepository.GetByID(ctx, test.want.ID)
+			got, err := accountRepository.GetByID(ctx, types.AccountID(test.wanted))
 			assert.Equal(t, (err != nil), test.wantErr)
-			assert.Equal(t, test.want.Name, got.Name)
+			assert.Equal(t, test.want, got)
 		})
 	}
 }

--- a/app/gateway/database/postgres/accounts/get_by_id_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_id_test.go
@@ -5,7 +5,6 @@ import (
 	"stoneBanking/app/domain/entities/account"
 	"stoneBanking/app/domain/types"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -14,7 +13,6 @@ func Test_GetByID(t *testing.T) {
 	ctx := context.Background()
 	database := databaseTest
 	accountRepository := NewAccountRepository(database)
-	now := time.Now()
 	testCases := []struct {
 		name    string
 		input   account.Account
@@ -25,29 +23,26 @@ func Test_GetByID(t *testing.T) {
 		{
 			name: "localizado a conta usando o ID externo (uuid), e retorna os dados da mesma ",
 			input: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: now,
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			want: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: now,
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			wanted:  "d3280f8c-570a-450d-89f7-3509bc84980d",
 			wantErr: false,
 		}, {
 			name: "retorna dados vazios e erro, ao tentar localizar conta com ID inexistente",
 			input: account.Account{
-				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:      "Joao da Silva",
-				CPF:       "38330499912",
-				Balance:   10000,
-				CreatedAt: now,
+				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:    "Joao da Silva",
+				CPF:     "38330499912",
+				Balance: 10000,
 			},
 			wanted: "d3280f8c-570a-450d-89f7-3509bc849899",
 			want: account.Account{

--- a/app/gateway/database/postgres/accounts/get_by_id_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_id_test.go
@@ -57,8 +57,12 @@ func Test_GetByID(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			TruncateTable(database)
 			_, err := accountRepository.Create(ctx, test.input)
 			got, err := accountRepository.GetByID(ctx, types.AccountID(test.wanted))
+			if err == nil {
+				test.want.CreatedAt = got.CreatedAt
+			}
 			assert.Equal(t, (err != nil), test.wantErr)
 			assert.Equal(t, test.want, got)
 		})

--- a/app/gateway/database/postgres/accounts/get_by_id_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_id_test.go
@@ -20,7 +20,7 @@ func Test_GetByID(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "localizado a conta usando o ID",
+			name: "localizado a conta usando o ID externo (uuid), e retorna os dados da mesma ",
 			input: account.Account{
 				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
 				Name:      "Joao da Silva",
@@ -36,7 +36,7 @@ func Test_GetByID(t *testing.T) {
 			},
 			wantErr: false,
 		}, {
-			name: "tentar localizar conta que não existe",
+			name: "retorna dados vazios e erro, ao tentar localizar conta com ID inexistente",
 			input: account.Account{
 				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
 				Name:      "Joao da Silva",

--- a/app/gateway/database/postgres/accounts/get_by_id_test.go
+++ b/app/gateway/database/postgres/accounts/get_by_id_test.go
@@ -13,6 +13,7 @@ func Test_GetByID(t *testing.T) {
 	ctx := context.Background()
 	database := databaseTest
 	accountRepository := NewAccountRepository(database)
+	now := time.Now()
 	testCases := []struct {
 		name    string
 		input   account.Account
@@ -26,13 +27,14 @@ func Test_GetByID(t *testing.T) {
 				Name:      "Joao da Silva",
 				CPF:       "38330499912",
 				Balance:   10000,
-				CreatedAt: time.Now(),
+				CreatedAt: now,
 			},
 			want: account.Account{
-				ID:      "d3280f8c-570a-450d-89f7-3509bc84980d",
-				Name:    "Joao da Silva",
-				CPF:     "38330499912",
-				Balance: 10000,
+				ID:        "d3280f8c-570a-450d-89f7-3509bc84980d",
+				Name:      "Joao da Silva",
+				CPF:       "38330499912",
+				Balance:   10000,
+				CreatedAt: now,
 			},
 			wantErr: false,
 		}, {
@@ -42,7 +44,7 @@ func Test_GetByID(t *testing.T) {
 				Name:      "Joao da Silva",
 				CPF:       "38330499912",
 				Balance:   10000,
-				CreatedAt: time.Now(),
+				CreatedAt: now,
 			},
 			want: account.Account{
 				ID:      "d3280f8c-570a-450d-89f7-3509bc849899",
@@ -58,9 +60,6 @@ func Test_GetByID(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := accountRepository.Create(ctx, test.input)
 			got, err := accountRepository.GetByID(ctx, test.want.ID)
-			if err == nil {
-				test.want.CreatedAt = got.CreatedAt
-			}
 			assert.Equal(t, (err != nil), test.wantErr)
 			assert.Equal(t, test.want.Name, got.Name)
 		})

--- a/app/gateway/database/postgres/accounts/main_test.go
+++ b/app/gateway/database/postgres/accounts/main_test.go
@@ -75,3 +75,12 @@ func DropTests(pool dockertest.Pool, resource *dockertest.Resource) {
 		log.Fatalf("Não foi possível limpar o banco - %s", err)
 	}
 }
+
+func TruncateTable(db *sql.DB) error {
+	sqlQuery := `TRUNCATE accounts`
+	_, err := db.Exec(sqlQuery)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/app/gateway/database/postgres/migrations/000001_create_accounts_table.up.sql
+++ b/app/gateway/database/postgres/migrations/000001_create_accounts_table.up.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS public.accounts(
     cpf           text                                         NOT NULL,
     secret        text                                         NOT NULL,
     balance       bigint                                       NOT NULL,
-    created_at    timestamp with time zone                     NOT NULL,
+    created_at    timestamp with time zone                     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT accounts_pkey PRIMARY KEY (id)
 );
 

--- a/app/gateway/database/postgres/migrations/000002_create_transfers_table.up.sql
+++ b/app/gateway/database/postgres/migrations/000002_create_transfers_table.up.sql
@@ -8,6 +8,6 @@ CREATE TABLE IF NOT EXISTS public.transfers
     account_destiny_id  VARCHAR(36)        NOT NULL,
     amount             bigint      NOT NULL DEFAULT 0,
     created_at          timestamp with time zone    NOT NULL
-);
+); 
 
 COMMIT;


### PR DESCRIPTION
Ajustado teste para quando tentar criar conta com CPF já existente (conta duplicada).
Além disso, melhorada a nomenclatura dos testes, para melhor legibilidade