### PR TITLE
refactor: change in the validation if a cpf exist in creation of account

### DIFF
--- a/app/application/usecase/account/create_account_test.go
+++ b/app/application/usecase/account/create_account_test.go
@@ -2,11 +2,14 @@ package account
 
 import (
 	"context"
+<<<<<<< HEAD
 	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+=======
+>>>>>>> refactor: corrected test that failed as sideeffect
 	"stoneBanking/app/domain/entities/account"
 	logHelper "stoneBanking/app/domain/entities/logger"
 	"stoneBanking/app/domain/entities/token"
@@ -29,9 +32,12 @@ func Test_Create(t *testing.T) {
 				CreateFunc: func(ctx context.Context, account account.Account) (account.Account, error) {
 					return account, nil
 				},
+<<<<<<< HEAD
 				GetCredentialByCPFFunc: func(ctx context.Context, accountCPF string) (account.Account, error) {
 					return account.Account{}, customError.ErrorAccountCPFNotFound
 				},
+=======
+>>>>>>> refactor: corrected test that failed as sideeffect
 			},
 			logMock: &logHelper.RepositoryMock{},
 			input: account.Account{
@@ -58,9 +64,12 @@ func Test_Create(t *testing.T) {
 				CreateFunc: func(ctx context.Context, account account.Account) (account.Account, error) {
 					return account, nil
 				},
+<<<<<<< HEAD
 				GetCredentialByCPFFunc: func(ctx context.Context, accountCPF string) (account.Account, error) {
 					return account.Account{}, customError.ErrorAccountCPFNotFound
 				},
+=======
+>>>>>>> refactor: corrected test that failed as sideeffect
 			},
 			logMock: &logHelper.RepositoryMock{},
 			input: account.Account{
@@ -78,6 +87,7 @@ func Test_Create(t *testing.T) {
 			name: "with right input data, try to create a account, but is duplicated from one that exist, and return error",
 			accountMock: &account.RepositoryMock{
 				CreateFunc: func(ctx context.Context, account account.Account) (account.Account, error) {
+<<<<<<< HEAD
 					return account, nil
 				},
 				GetCredentialByCPFFunc: func(ctx context.Context, accountCPF string) (account.Account, error) {
@@ -89,6 +99,9 @@ func Test_Create(t *testing.T) {
 						Secret:     "J0@0doR10",
 						Balance:    0,
 					}, nil
+=======
+					return account, customError.ErrorAccountCPFExists
+>>>>>>> refactor: corrected test that failed as sideeffect
 				},
 			},
 			logMock: &logHelper.RepositoryMock{},

--- a/app/application/usecase/account/create_account_test.go
+++ b/app/application/usecase/account/create_account_test.go
@@ -2,14 +2,11 @@ package account
 
 import (
 	"context"
-<<<<<<< HEAD
 	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-=======
->>>>>>> refactor: corrected test that failed as sideeffect
 	"stoneBanking/app/domain/entities/account"
 	logHelper "stoneBanking/app/domain/entities/logger"
 	"stoneBanking/app/domain/entities/token"
@@ -32,12 +29,9 @@ func Test_Create(t *testing.T) {
 				CreateFunc: func(ctx context.Context, account account.Account) (account.Account, error) {
 					return account, nil
 				},
-<<<<<<< HEAD
 				GetCredentialByCPFFunc: func(ctx context.Context, accountCPF string) (account.Account, error) {
 					return account.Account{}, customError.ErrorAccountCPFNotFound
 				},
-=======
->>>>>>> refactor: corrected test that failed as sideeffect
 			},
 			logMock: &logHelper.RepositoryMock{},
 			input: account.Account{
@@ -64,12 +58,9 @@ func Test_Create(t *testing.T) {
 				CreateFunc: func(ctx context.Context, account account.Account) (account.Account, error) {
 					return account, nil
 				},
-<<<<<<< HEAD
 				GetCredentialByCPFFunc: func(ctx context.Context, accountCPF string) (account.Account, error) {
 					return account.Account{}, customError.ErrorAccountCPFNotFound
 				},
-=======
->>>>>>> refactor: corrected test that failed as sideeffect
 			},
 			logMock: &logHelper.RepositoryMock{},
 			input: account.Account{
@@ -87,21 +78,10 @@ func Test_Create(t *testing.T) {
 			name: "with right input data, try to create a account, but is duplicated from one that exist, and return error",
 			accountMock: &account.RepositoryMock{
 				CreateFunc: func(ctx context.Context, account account.Account) (account.Account, error) {
-<<<<<<< HEAD
-					return account, nil
+					return account, customError.ErrorAccountCPFExists
 				},
 				GetCredentialByCPFFunc: func(ctx context.Context, accountCPF string) (account.Account, error) {
-					return account.Account{
-						ID:         1,
-						Name:       "Joao do Rio",
-						ExternalID: "94b9c27e-2880-42e3-8988-62dceb6b6463",
-						CPF:        "761.647.810-78",
-						Secret:     "J0@0doR10",
-						Balance:    0,
-					}, nil
-=======
-					return account, customError.ErrorAccountCPFExists
->>>>>>> refactor: corrected test that failed as sideeffect
+					return account.Account{}, nil
 				},
 			},
 			logMock: &logHelper.RepositoryMock{},

--- a/app/gateway/database/postgres/accounts/create_account.go
+++ b/app/gateway/database/postgres/accounts/create_account.go
@@ -6,7 +6,6 @@ import (
 	"stoneBanking/app/domain/entities/account"
 	customError "stoneBanking/app/domain/errors"
 	"stoneBanking/app/gateway/database/postgres/pgerrors"
-	"strings"
 
 	"github.com/lib/pq"
 )
@@ -32,7 +31,7 @@ func (repository accountRepository) Create(ctx context.Context, newAccount accou
 	err := row.Scan(&newAccount.ID, &newAccount.ExternalID, &newAccount.CreatedAt)
 	if err != nil {
 		if pgErr, ok := err.(*pq.Error); ok {
-			if pgErr.Code == pgerrors.UniqueViolationCode && strings.Contains(err.Error(), "accounts_cpf_uk") {
+			if pgErr.Code == pgerrors.UniqueViolationCode && pgErr.Constraint == "accounts_cpf_uk" {
 				return account.Account{}, customError.ErrorAccountCPFExists
 			}
 		}

--- a/app/gateway/database/postgres/accounts/create_account.go
+++ b/app/gateway/database/postgres/accounts/create_account.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"stoneBanking/app/domain/entities/account"
+	customError "stoneBanking/app/domain/errors"
+	"strings"
 )
 
 func (repository accountRepository) Create(ctx context.Context, newAccount account.Account) (account.Account, error) {
@@ -27,6 +29,10 @@ func (repository accountRepository) Create(ctx context.Context, newAccount accou
 	err := row.Scan(&newAccount.ID, &newAccount.ExternalID, &newAccount.CreatedAt)
 
 	if err != nil {
+		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+			return account.Account{}, customError.ErrorAccountCPFExists
+		}
+
 		return account.Account{}, err
 	}
 

--- a/app/gateway/database/postgres/accounts/create_account.go
+++ b/app/gateway/database/postgres/accounts/create_account.go
@@ -28,11 +28,11 @@ func (repository accountRepository) Create(ctx context.Context, newAccount accou
 		newAccount.Balance.ToInt(),
 	)
 
+	const uniqueViolationCode = "23505"
 	err := row.Scan(&newAccount.ID, &newAccount.ExternalID, &newAccount.CreatedAt)
-
 	if err != nil {
 		if pgErr, ok := err.(*pq.Error); ok {
-			if pgErr.Code == "23505" && strings.Contains(err.Error(), "accounts_cpf_key") {
+			if pgErr.Code == uniqueViolationCode && strings.Contains(err.Error(), "accounts_cpf_uk") {
 				return account.Account{}, customError.ErrorAccountCPFExists
 			}
 		}

--- a/app/gateway/database/postgres/accounts/create_account.go
+++ b/app/gateway/database/postgres/accounts/create_account.go
@@ -5,6 +5,7 @@ import (
 
 	"stoneBanking/app/domain/entities/account"
 	customError "stoneBanking/app/domain/errors"
+	"stoneBanking/app/gateway/database/postgres/pgerrors"
 	"strings"
 
 	"github.com/lib/pq"
@@ -28,11 +29,10 @@ func (repository accountRepository) Create(ctx context.Context, newAccount accou
 		newAccount.Balance.ToInt(),
 	)
 
-	const uniqueViolationCode = "23505"
 	err := row.Scan(&newAccount.ID, &newAccount.ExternalID, &newAccount.CreatedAt)
 	if err != nil {
 		if pgErr, ok := err.(*pq.Error); ok {
-			if pgErr.Code == uniqueViolationCode && strings.Contains(err.Error(), "accounts_cpf_uk") {
+			if pgErr.Code == pgerrors.UniqueViolationCode && strings.Contains(err.Error(), "accounts_cpf_uk") {
 				return account.Account{}, customError.ErrorAccountCPFExists
 			}
 		}

--- a/app/gateway/database/postgres/migrations/000001_create_accounts_table.up.sql
+++ b/app/gateway/database/postgres/migrations/000001_create_accounts_table.up.sql
@@ -4,10 +4,12 @@ CREATE TABLE IF NOT EXISTS public.accounts(
     id            INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     external_id   uuid                                         NOT NULL default gen_random_uuid(), 
     name          text                                         NOT NULL,
-    cpf           text                                         NOT NULL UNIQUE,
+    cpf           text                                         NOT NULL,
     secret        text                                         NOT NULL,
     balance       bigint                                       NOT NULL,
     created_at    timestamp with time zone                     NOT NULL DEFAULT CURRENT_TIMESTAMP
+
+    CONSTRAINT account_cpf_uk UNIQUE (cpf)
 );
 
 COMMIT;

--- a/app/gateway/database/postgres/migrations/000001_create_accounts_table.up.sql
+++ b/app/gateway/database/postgres/migrations/000001_create_accounts_table.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS public.accounts(
     cpf           text                                         NOT NULL,
     secret        text                                         NOT NULL,
     balance       bigint                                       NOT NULL,
-    created_at    timestamp with time zone                     NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at    timestamp with time zone                     NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT account_cpf_uk UNIQUE (cpf)
 );

--- a/app/gateway/database/postgres/pgerrors/pgerrors.go
+++ b/app/gateway/database/postgres/pgerrors/pgerrors.go
@@ -1,0 +1,5 @@
+package pgerrors
+
+const (
+	UniqueViolationCode = "23505"
+)


### PR DESCRIPTION
Changed from validating if a cpf exist, to validating if return a error (unique_violation) in the moment of creation.
Close #97 