### PR TITLE
feat: add to the validation of account the possibility to return multiply errors

### DIFF
--- a/app/gateway/http/account/create_account.go
+++ b/app/gateway/http/account/create_account.go
@@ -44,10 +44,9 @@ func (c *Controller) Create(w http.ResponseWriter, r *http.Request) {
 	accountInput.CPF = accountInput.CPF.TrimCPF()
 
 	c.log.LogInfo(operation, "begin the validation of the input data")
-	accountInput, err = validations.ValidateAccountInput(accountInput)
-	if err != nil {
-		c.log.LogError(operation, err.Error())
-		resp.BadRequest(response.NewError(err))
+	errs := validations.ValidateAccountInput(accountInput)
+	if errs != nil {
+		resp.BadRequest(response.NewErrors(errs))
 		return
 	}
 

--- a/app/gateway/http/account/create_account_test.go
+++ b/app/gateway/http/account/create_account_test.go
@@ -38,7 +38,7 @@ func Test_Create(t *testing.T) {
 		fields   fields
 		args     args
 		wantCode int
-		wantBody map[string]interface{}
+		wantBody string
 	}{
 		{
 			name: "with the right data, account is created successfully",
@@ -73,13 +73,14 @@ func Test_Create(t *testing.T) {
 				},
 			},
 			wantCode: http.StatusCreated,
-			wantBody: map[string]interface{}{
+			wantBody: `
+			{
 				"id":         "94b9c27e-2880-42e3-8988-62dceb6b6463",
 				"name":       "Joao do Rio",
 				"cpf":        "761.647.810-78",
 				"balance":    0,
-				"created_at": "0001-01-01T00:00:00Z",
-			},
+				"created_at": "0001-01-01T00:00:00Z"
+			}`,
 		},
 		{
 			name: "data from input without name, generating error in validation",
@@ -114,9 +115,11 @@ func Test_Create(t *testing.T) {
 				},
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: map[string]interface{}{
-				"error": "the field 'Name' is required",
-			},
+			wantBody: `[
+				{
+					"error": "the field 'Name' is required"
+				}
+			]`,
 		},
 		{
 			name: "data from input with a negative amount in origin, generating error in validation",
@@ -144,9 +147,11 @@ func Test_Create(t *testing.T) {
 				},
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: map[string]interface{}{
-				"error": "the field 'Balance' need to by equal or major than 0(zero)",
-			},
+			wantBody: `[
+				{
+					"error": "the field 'Balance' need to by equal or major than 0(zero)"
+				}
+				]`,
 		},
 		{
 			name: "with correct data, but have a error when creating the account in database",
@@ -174,9 +179,9 @@ func Test_Create(t *testing.T) {
 				},
 			},
 			wantCode: http.StatusInternalServerError,
-			wantBody: map[string]interface{}{
-				"error": "error when creating a new account",
-			},
+			wantBody: `{
+				"error": "error when creating a new account"
+			}`,
 		},
 	}
 
@@ -195,10 +200,7 @@ func Test_Create(t *testing.T) {
 
 			assert.Equal(t, test.wantCode, rec.Code)
 
-			if test.wantBody != nil {
-				wantBodyJson, _ := json.Marshal(test.wantBody)
-				assert.JSONEq(t, string(wantBodyJson), rec.Body.String())
-			}
+			assert.JSONEq(t, test.wantBody, rec.Body.String())
 		})
 	}
 

--- a/app/gateway/http/account/vo/input/validations/create_account.go
+++ b/app/gateway/http/account/vo/input/validations/create_account.go
@@ -5,28 +5,33 @@ import (
 	"stoneBanking/app/gateway/http/account/vo/input"
 )
 
-func ValidateAccountInput(accountData input.CreateAccountVO) (input.CreateAccountVO, error) {
+func ValidateAccountInput(accountData input.CreateAccountVO) []error {
 	_, err := validateName(accountData.Name)
+	var errs = make([]error, 0)
 	if err != nil {
-		return input.CreateAccountVO{}, err
+		errs = append(errs, err)
 	}
 
 	_, err = validateCPF(accountData.CPF.ToString())
 	if err != nil {
-		return input.CreateAccountVO{}, err
+		errs = append(errs, err)
 	}
 
 	_, err = validateSecret(accountData.Secret.ToString())
 	if err != nil {
-		return input.CreateAccountVO{}, err
+		errs = append(errs, err)
 	}
 
 	_, err = validateBalance(accountData.Balance)
 	if err != nil {
-		return input.CreateAccountVO{}, err
+		errs = append(errs, err)
 	}
 
-	return accountData, nil
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
 }
 
 func validateName(name string) (bool, error) {

--- a/app/gateway/http/account/vo/input/validations/create_account_test.go
+++ b/app/gateway/http/account/vo/input/validations/create_account_test.go
@@ -112,10 +112,9 @@ func Test_ValidateAccountInput(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 
-			got, err := ValidateAccountInput(test.input)
+			err := ValidateAccountInput(test.input)
 
 			assert.Equal(t, (err != nil), test.wantErr)
-			assert.Equal(t, test.want, got)
 		})
 	}
 }

--- a/app/gateway/http/response/error.go
+++ b/app/gateway/http/response/error.go
@@ -9,3 +9,11 @@ func NewError(err error) *OutputError {
 		Error: err.Error(),
 	}
 }
+
+func NewErrors(errs []error) *[]OutputError {
+	var output = make([]OutputError, 0)
+	for _, err := range errs {
+		output = append(output, OutputError{Error: err.Error()})
+	}
+	return &output
+}


### PR DESCRIPTION
## Description
Changed lib used in the database layer from sql.DB to pgx, and treated side effects in text, and little differences in the calling of some functions (previously not use the context in the call of the queries, now is needed).

## Changes
- Changed ValidateAccount (VO/Input/accounts) to return multiply errors case this happen, to have a better return to the frontend.
- Created function to generate a output object using a list of errors.
- Make the correspondent changes in the function in gateway/http, to use the new changes.
Close #88 

## Checklist

#### Readme:
- [x] My changes do not require changing README.md
- [ ] My changes require changing the README.md and I made the necessary changes.

#### Docs:
- [X] My changes do not require changing Documentation (Swagger, Rapidocs, etc)
- [] My changes require changing the Documentation and I made the necessary changes.

### Env vars:
- [x] I didn't add/change any env var
- [ ] I configured env var new/changed in render.sh (if necessary)
- [ ] I put/Updated env var new/changed in .env-example