### PR TITLE
feat: add mutext to block to controll parallelism

### DIFF
--- a/app/application/usecase/transfer/create_transfer.go
+++ b/app/application/usecase/transfer/create_transfer.go
@@ -10,6 +10,7 @@ import (
 
 func (u *usecase) Create(ctx context.Context, transferData transfer.Transfer) (transfer.Transfer, error) {
 	const operation = "Usecase.Transfer.Create"
+	u.m.Lock()
 
 	u.logger.LogDebug(operation, "searching for account of origin")
 	accountOrigin, err := u.accountRepository.GetByID(ctx, types.ExternalID(transferData.AccountOriginExternalID))
@@ -45,7 +46,7 @@ func (u *usecase) Create(ctx context.Context, transferData transfer.Transfer) (t
 		u.logger.LogError(operation, err.Error())
 		return transfer.Transfer{}, customError.ErrorTransferCreate
 	}
-
+	u.m.Unlock()
 	u.logger.LogDebug(operation, "transfer created successfully")
 	return newTransfer, nil
 }

--- a/app/application/usecase/transfer/create_transfer_test.go
+++ b/app/application/usecase/transfer/create_transfer_test.go
@@ -193,8 +193,8 @@ func Test_Create(t *testing.T) {
 			Amount:                       100,
 		}
 		u := New(tRepo, accountRepo, &logHelper.RepositoryMock{})
-		go u.Create(ctx, transfer1)
-		go u.Create(ctx, transfer2)
+		go u.Create(ctx, transfer1) //nolint
+		go u.Create(ctx, transfer2) //nolint
 
 		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, int32(1), tRepo.Count)

--- a/app/application/usecase/transfer/create_transfer_test.go
+++ b/app/application/usecase/transfer/create_transfer_test.go
@@ -192,6 +192,7 @@ func Test_Create(t *testing.T) {
 			AccountDestinationExternalID: "94b9c27e-2880-42e3-8988-62dceb6b6463",
 			Amount:                       100,
 		}
+		// Run the two creates in parallel with the aim of trying to make two simultaneous insertions, the mutex should hold one of them, leaving only the first one through
 		u := New(tRepo, accountRepo, &logHelper.RepositoryMock{})
 		go u.Create(ctx, transfer1) //nolint
 		go u.Create(ctx, transfer2) //nolint
@@ -199,6 +200,7 @@ func Test_Create(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, int32(1), tRepo.Count)
 
+		// sends release to the channel, so that counter validation and evaluation can continue
 		tRepo.WaitChan <- true
 		time.Sleep(10 * time.Millisecond)
 		assert.Equal(t, int32(2), tRepo.Count)

--- a/app/application/usecase/transfer/usecase.go
+++ b/app/application/usecase/transfer/usecase.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"context"
+	"sync"
 
 	"stoneBanking/app/domain/entities/account"
 	logHelper "stoneBanking/app/domain/entities/logger"
@@ -18,6 +19,7 @@ type usecase struct {
 	transferRepository transfer.Repository
 	accountRepository  account.Repository
 	logger             logHelper.Logger
+	m                  *sync.Mutex
 }
 
 func New(transfer transfer.Repository, account account.Repository, log logHelper.Logger) *usecase {
@@ -25,5 +27,6 @@ func New(transfer transfer.Repository, account account.Repository, log logHelper
 		transferRepository: transfer,
 		accountRepository:  account,
 		logger:             log,
+		m:                  &sync.Mutex{},
 	}
 }

--- a/app/domain/entities/transfer/mock.go
+++ b/app/domain/entities/transfer/mock.go
@@ -34,13 +34,13 @@ type ParallelMock struct {
 	GetByIDFunc           func(ctx context.Context, transferID types.ExternalID) (Transfer, error)
 	GetAllFunc            func(ctx context.Context) ([]Transfer, error)
 	GetAllByAccountIDFunc func(ctx context.Context, accountID types.InternalID) ([]Transfer, error)
-	count                 int32
-	waitChan              chan bool
+	Count                 int32
+	WaitChan              chan bool
 }
 
 func (pr *ParallelMock) Create(ctx context.Context, transfer Transfer) (Transfer, error) {
-	atomic.AddInt32(&pr.count, 1)
-	<-pr.waitChan
+	atomic.AddInt32(&pr.Count, 1)
+	<-pr.WaitChan
 	return pr.CreateFunc(ctx, transfer)
 }
 

--- a/app/domain/entities/transfer/mock.go
+++ b/app/domain/entities/transfer/mock.go
@@ -40,7 +40,9 @@ type ParallelMock struct {
 
 func (pr *ParallelMock) Create(ctx context.Context, transfer Transfer) (Transfer, error) {
 	atomic.AddInt32(&pr.Count, 1)
-	<-pr.WaitChan
+	if <-pr.WaitChan {
+		close(pr.WaitChan)
+	}
 	return pr.CreateFunc(ctx, transfer)
 }
 


### PR DESCRIPTION
## Description
Add [Mutex](https://go.dev/tour/concurrency/9) to the struct, to better control the possibility of request parallel to the same account, creating in this way a sequence of calls and granting in this way the integrity of data.
For the test, he as made separately because his design and intention are different from the others, being in yourself a test directed for the numbers of calls received by the function, and not directed for the results obtained in the end (reason that the returns are ignore in the lint).
Close #94

## Changes
- add mutex to requisites of usecase struct
- use usecase.mutext to lock and unlock in the creation of transfer
- add test to usecase, to grant the correct use of parallel

## Checklist

#### Readme:
- [x] My changes do not require changing README.md
- [ ] My changes require changing the README.md and I made the necessary changes.

#### Docs:
- [x] My changes do not require changing Documentation (Swagger, Rapidocs, etc)
- [ ] My changes require changing the Documentation and I made the necessary changes.

### Env vars:
- [x] I didn't add/change any env var
- [ ] I configured env var new/changed in render.sh (if necessary)
- [ ] I put/Updated env var new/changed in .env-example